### PR TITLE
Support 'handle error once' idiom

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/gostaticanalysis/comment v1.0.0 h1:RfOgsu3EvAKTY0aQ0/5GNl6wdhy6xuuRP9g72AwICTw=
-github.com/gostaticanalysis/comment v1.0.0/go.mod h1:xMicKDx7XRXYdVwY9f9wQpDJVnqWxw9wCauCMKp+IBI=
 github.com/gostaticanalysis/comment v1.3.0 h1:wTVgynbFu8/nz6SGgywA0TcyIoAVsYc7ai/Zp5xNGlw=
 github.com/gostaticanalysis/comment v1.3.0/go.mod h1:xMicKDx7XRXYdVwY9f9wQpDJVnqWxw9wCauCMKp+IBI=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -1,6 +1,7 @@
 package a
 
 import (
+	"context"
 	"errors"
 	"log"
 )
@@ -46,12 +47,27 @@ func g() error {
 	}
 
 	if err := do(); err != nil {
-		CustomLoggingFunc(err) // OK, error is used (most probably, for logging)
+		CustomLoggingFunc(err) // OK
 		return nil
 	}
 
 	if err := do(); err != nil {
-		NewLogger().CustomLoggingFunc(err) // OK, error is used (most probably, for logging)
+		Logf(context.Background(), "error: %+v", err) // OK
+		return nil
+	}
+
+	if err := do(); err != nil {
+		LogTypedf(context.Background(), "error: %+v", err) // OK
+		return nil
+	}
+
+	if err := do(); err != nil {
+		LogSinglef(context.Background(), "error: %+v", err) // OK
+		return nil
+	}
+
+	if err := do(); err != nil {
+		NewLogger().CustomLoggingFunc(err) // OK
 		return nil
 	}
 
@@ -65,6 +81,18 @@ func g() error {
 
 func CustomLoggingFunc(err error) {
 	log.Printf("%+v", err)
+}
+
+func Logf(ctx context.Context, msg string, args ...interface{}) {
+	log.Printf(msg, args...)
+}
+
+func LogTypedf(ctx context.Context, msg string, args ...error) {
+	log.Printf(msg, args[0])
+}
+
+func LogSinglef(ctx context.Context, msg string, arg interface{}) {
+	log.Printf(msg, arg)
 }
 
 type logger int

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -7,18 +7,14 @@ import (
 	"testing"
 )
 
-func do() error {
-	return nil
-}
-
 func f() error {
 	err := do()
 	if err != nil {
-		return nil // want "error is not nil \\(line 15\\) but it returns nil"
+		return nil // want "error is not nil \\(line 11\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
-		return nil // want "error is not nil \\(line 20\\) but it returns nil"
+		return nil // want "error is not nil \\(line 16\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
@@ -32,10 +28,16 @@ func f() error {
 func g() error {
 	err := do()
 	if err == nil {
-		return err // want "error is nil \\(line 33\\) but it returns error"
+		return err // want "error is nil \\(line 29\\) but it returns error"
 	}
 
 	if err := do(); err == nil {
+		return err // want "error is nil \\(line 34\\) but it returns error"
+	}
+
+	bytes, err := do2()
+	if err == nil {
+		_ = bytes
 		return err // want "error is nil \\(line 38\\) but it returns error"
 	}
 
@@ -87,7 +89,7 @@ func h() {
 				break
 			}
 		}
-		return nil // want "error is not nil \\(line 86\\) but it returns nil"
+		return nil // want "error is not nil \\(line 88\\) but it returns nil"
 	}
 	_ = f0
 
@@ -100,6 +102,14 @@ func h() {
 		return nil
 	}
 	_ = f1
+}
+
+func do() error {
+	return nil
+}
+
+func do2() ([]byte, error) {
+	return nil, nil
 }
 
 func CustomLoggingFunc(err error) {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -154,6 +154,34 @@ func k()  {
 	}
 }
 
+func l() error {
+	var e = errors.New("x")
+
+	bytes, err := do2()
+	if err != nil {
+		return err
+	}
+	defer func() error {return nil}()
+
+	for {
+		var buf []byte
+		buf, err = do2()
+		if err == e {
+			for err == e {
+				_, err = do2()
+			}
+			if err != nil {
+				err = errors.New("a")
+				break
+			}
+		}
+		_ = buf
+	}
+
+	_ = bytes
+	return nil // want "error is not nil \\(lines \\[168 171\\]\\) but it returns nil"
+}
+
 func do() error {
 	return nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -1,6 +1,9 @@
 package a
 
-import "errors"
+import (
+	"errors"
+	"log"
+)
 
 func do() error {
 	return nil
@@ -39,9 +42,38 @@ func g() error {
 	}
 
 	if err := do(); err != nil {
+		return errors.New(err.Error()) // OK, error is wrapped
+	}
+
+	if err := do(); err != nil {
+		CustomLoggingFunc(err) // OK, error is used (most probably, for logging)
+		return nil
+	}
+
+	if err := do(); err != nil {
+		NewLogger().CustomLoggingFunc(err) // OK, error is used (most probably, for logging)
+		return nil
+	}
+
+	if err := do(); err != nil {
 		//lint:ignore nilerr reason
 		return nil // OK
 	}
 
 	return nil
+}
+
+func CustomLoggingFunc(err error) {
+	log.Printf("%+v", err)
+}
+
+type logger int
+
+func NewLogger() *logger {
+	l := logger(0)
+	return &l
+}
+
+func (l *logger) CustomLoggingFunc(err error) {
+	log.Printf("%+v", err)
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -22,23 +22,28 @@ func f() error {
 		return nil // OK
 	}
 
+	err = do()
+	if err == nil || checkErr(err) {
+		return err
+	}
+
 	return nil
 }
 
 func g() error {
 	err := do()
 	if err == nil {
-		return err // want "error is nil \\(line 29\\) but it returns error"
+		return err // want "error is nil \\(line 34\\) but it returns error"
 	}
 
 	if err := do(); err == nil {
-		return err // want "error is nil \\(line 34\\) but it returns error"
+		return err // want "error is nil \\(line 39\\) but it returns error"
 	}
 
 	bytes, err := do2()
 	if err == nil {
 		_ = bytes
-		return err // want "error is nil \\(line 38\\) but it returns error"
+		return err // want "error is nil \\(line 43\\) but it returns error"
 	}
 
 	if err := do(); err == nil {
@@ -56,6 +61,11 @@ func g() error {
 
 	if err := do(); err != nil {
 		Logf(context.Background(), "error: %+v", err) // OK
+		return nil
+	}
+
+	if err := do(); err != nil {
+		Logf(context.Background(), "error: %s", err.Error()) // OK
 		return nil
 	}
 
@@ -89,7 +99,7 @@ func h() {
 				break
 			}
 		}
-		return nil // want "error is not nil \\(line 88\\) but it returns nil"
+		return nil // want "error is not nil \\(line 98\\) but it returns nil"
 	}
 	_ = f0
 
@@ -106,7 +116,7 @@ func h() {
 
 func i() (error, error) {
 	if err := do(); err != nil {
-		return nil, nil // want "error is not nil \\(line 108\\) but it returns nil"
+		return nil, nil // want "error is not nil \\(line 118\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
@@ -126,7 +136,7 @@ func i() (error, error) {
 
 func j() (interface{}, error) {
 	if err := do(); err != nil {
-		return nil, nil // want "error is not nil \\(line 128\\) but it returns nil"
+		return nil, nil // want "error is not nil \\(line 138\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
@@ -134,7 +144,7 @@ func j() (interface{}, error) {
 	}
 
 	if err := do(); err != nil {
-		return err, nil // want "error is not nil \\(line 136\\) but it returns nil"
+		return err, nil // want "error is not nil \\(line 146\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
@@ -179,7 +189,7 @@ func l() error {
 	}
 
 	_ = bytes
-	return nil // want "error is not nil \\(lines \\[168 171\\]\\) but it returns nil"
+	return nil // want "error is not nil \\(lines \\[178 181\\]\\) but it returns nil"
 }
 
 func do() error {
@@ -188,6 +198,10 @@ func do() error {
 
 func do2() ([]byte, error) {
 	return nil, nil
+}
+
+func checkErr(err error) bool {
+	return true
 }
 
 func CustomLoggingFunc(err error) {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -104,6 +104,56 @@ func h() {
 	_ = f1
 }
 
+func i() (error, error) {
+	if err := do(); err != nil {
+		return nil, nil // want "error is not nil \\(line 108\\) but it returns nil"
+	}
+
+	if err := do(); err != nil {
+		return nil, err
+	}
+
+	if err := do(); err != nil {
+		return err, nil
+	}
+
+	if err := do(); err != nil {
+		return err, err
+	}
+
+	return nil, nil
+}
+
+func j() (interface{}, error) {
+	if err := do(); err != nil {
+		return nil, nil // want "error is not nil \\(line 128\\) but it returns nil"
+	}
+
+	if err := do(); err != nil {
+		return nil, err
+	}
+
+	if err := do(); err != nil {
+		return err, nil // want "error is not nil \\(line 136\\) but it returns nil"
+	}
+
+	if err := do(); err != nil {
+		return err, err
+	}
+
+	return nil, nil
+}
+
+func k()  {
+	if err := do(); err != nil {
+		return
+	}
+
+	if err := do(); err == nil {
+		return
+	}
+}
+
 func do() error {
 	return nil
 }

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"testing"
 )
 
 func do() error {
@@ -13,11 +14,11 @@ func do() error {
 func f() error {
 	err := do()
 	if err != nil {
-		return nil // want "error is not nil but it returns nil"
+		return nil // want "error is not nil \\(line 15\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
-		return nil // want "error is not nil but it returns nil"
+		return nil // want "error is not nil \\(line 20\\) but it returns nil"
 	}
 
 	if err := do(); err != nil {
@@ -31,11 +32,11 @@ func f() error {
 func g() error {
 	err := do()
 	if err == nil {
-		return err // want "error is nil but it returns error"
+		return err // want "error is nil \\(line 33\\) but it returns error"
 	}
 
 	if err := do(); err == nil {
-		return err // want "error is nil but it returns error"
+		return err // want "error is nil \\(line 38\\) but it returns error"
 	}
 
 	if err := do(); err == nil {
@@ -77,6 +78,28 @@ func g() error {
 	}
 
 	return nil
+}
+
+func h() {
+	f0 := func() error {
+		for {
+			if err := do(); err != nil {
+				break
+			}
+		}
+		return nil // want "error is not nil \\(line 86\\) but it returns nil"
+	}
+	_ = f0
+
+	f1 := func(t *testing.T) error {
+		for {
+			if err := do(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return nil
+	}
+	_ = f1
 }
 
 func CustomLoggingFunc(err error) {


### PR DESCRIPTION
In go, it is considered common practice to only handle error once. That is, either log it / handle in some other way, or pass along.
The first reference I found is in this article: https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully (**Only handle errors once** chapter), and I'm sure there's more.

The suggested change is a result of adopting `nilerr` in one example of a big codebase. With these changes, we were able to reach 'no violations' state and add this check to CI. 
This is a good real life test, but some unintended specifics might have crept in, and I would be happy to fix or generalise them, if necessary.

The sum of changes:
- if err is used as an argument in a function call, it is not considered a mistake to return nil
- such uses with `.Error()` and with non-err or vararg parameters are also supported
- a line number is added to waning text, because in some cases the offending error assignment is not that easy to find
- multiple possible assignments are supported - for example, if err is checked and then overwritten in a loop
- after a negative err check, warning is not issued if there are other conditions in if statement
- added support for multiple error return values

Tests have been added for all those cases, so looking in the test file first may be the best way to see the overview of changes in terms of warnings issued. 