### PR TITLE
use comment.Maps.IgnorePos() instead of IgnoreLine()

### DIFF
--- a/nilerr.go
+++ b/nilerr.go
@@ -30,9 +30,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	reportFail := func(v ssa.Value, ret *ssa.Return, format string) {
 		pos := ret.Pos()
-		line := getNodeLineNumber(pass, ret)
 		errLines := getValueLineNumbers(pass, v)
-		if !cmaps.IgnoreLine(pass.Fset, line, "nilerr") {
+		if !cmaps.IgnorePos(pos, "nilerr") {
 			var errLineText string
 			if len(errLines) == 1 {
 				errLineText = fmt.Sprintf("line %d", errLines[0])
@@ -81,11 +80,6 @@ func getValueLineNumbers(pass *analysis.Pass, v ssa.Value) []int {
 
 	pos := value.Pos()
 	return []int{pass.Fset.File(pos).Line(pos)}
-}
-
-func getNodeLineNumber(pass *analysis.Pass, node ssa.Node) int {
-	pos := node.Pos()
-	return pass.Fset.File(pos).Line(pos)
 }
 
 var errType = types.Universe.Lookup("error").Type().Underlying().(*types.Interface)


### PR DESCRIPTION
nilerr sometimes fails to find `lint:ignore` comments. This is because
nilerr checks if this comment exists by `comment.Maps.IgnoreLine()`,
which does not work well with multiple files. For example, nilerr
mistakenly ignores `lint:ignore` with the following files.

```
-- f.go --
package main

import "errors"

func f() error {
        err := errors.New("error")
        if err != nil {
                //lint:ignore nilerr reason
                return nil
        }
        return nil
}

-- g.go --
package main

import "errors"

func g() error {
        err := errors.New("error")
        if err != nil {
                // not ignored
                return err
        }
        return nil
}
```

This patch changes to use `IgnorePos()` that is safe to use with
multiple files.