### PR TITLE
[v0.1.2] false negative in function with defer

### DIFF
--- a/nilerr.go
+++ b/nilerr.go
@@ -172,14 +172,12 @@ func isReturnNil(b *ssa.BasicBlock) *ssa.Return {
 		// func(...) (a,b,...,z) -> Store a, Store b, ..., Store z, RunDefers
 		deferredResults := make([]ssa.Value, 0, len(res))
 		for idx, i := range b.Instrs {
-			if ok := isRunDeferP(i); ok && idx == len(res) {
-				return deferredResults // kosher defer
-			} else if idx == len(res) || ok {
-				return res
-			} else if store, ok := i.(*ssa.Store); !ok {
-				return res
-			} else {
+			if store, storeOk := i.(*ssa.Store); storeOk { // up to defer in right idx
 				deferredResults = append(deferredResults, store.Val)
+			} else if rdOk := isRunDeferP(i); rdOk && idx == len(res) {
+				return deferredResults // kosher defer
+			} else {
+				break
 			}
 		}
 		return res

--- a/nilerr.go
+++ b/nilerr.go
@@ -165,12 +165,14 @@ func isReturnNil(b *ssa.BasicBlock) *ssa.Return {
 
 	retResults := func() []ssa.Value {
 		res := ret.Results
+		isRunDeferP := func(i ssa.Instruction) bool { _, ok := i.(*ssa.RunDefers); return ok }
+		if len(b.Instrs) <= len(res) || !isRunDeferP(b.Instrs[len(res)]) {
+			return res // defer is not in place
+		}
 		// func(...) (a,b,...,z) -> Store a, Store b, ..., Store z, RunDefers
 		deferredResults := make([]ssa.Value, 0, len(res))
-		for idx := 0; idx < len(b.Instrs); idx++ {
-			i := b.Instrs[idx]
-
-			if _, ok := i.(*ssa.RunDefers); ok && idx == len(res) {
+		for idx, i := range b.Instrs {
+			if ok := isRunDeferP(i); ok && idx == len(res) {
 				return deferredResults // kosher defer
 			} else if idx == len(res) || ok {
 				return res

--- a/nilerr.go
+++ b/nilerr.go
@@ -163,8 +163,28 @@ func isReturnNil(b *ssa.BasicBlock) *ssa.Return {
 		return nil
 	}
 
+	retResults := func() []ssa.Value {
+		res := ret.Results
+		// func(...) (a,b,...,z) -> Store a, Store b, ..., Store z, RunDefers
+		deferredResults := make([]ssa.Value, 0, len(res))
+		for idx := 0; idx < len(b.Instrs); idx++ {
+			i := b.Instrs[idx]
+
+			if _, ok := i.(*ssa.RunDefers); ok && idx == len(res) {
+				return deferredResults // kosher defer
+			} else if idx == len(res) || ok {
+				return res
+			} else if store, ok := i.(*ssa.Store); !ok {
+				return res
+			} else {
+				deferredResults = append(deferredResults, store.Val)
+			}
+		}
+		return res
+	}()
+
 	errorReturnValues := 0
-	for _, res := range ret.Results {
+	for _, res := range retResults {
 		if !types.Implements(res.Type(), errType) {
 			continue
 		}

--- a/nilerr_test.go
+++ b/nilerr_test.go
@@ -7,7 +7,18 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-func Test(t *testing.T) {
+func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, nilerr.Analyzer, "a")
+	tests := []struct {
+		name string
+		file string
+	}{
+		{"basic", "a"},
+		{"defers", "defers"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			analysistest.Run(t, testdata, nilerr.Analyzer, test.file)
+		})
+	}
 }

--- a/testdata/src/defers/defers.go
+++ b/testdata/src/defers/defers.go
@@ -1,0 +1,89 @@
+package defers
+
+func simpleFuncWithOneErr() error {
+	if err := do(); err != nil {
+		return err
+	}
+	if err := do(); err != nil {
+		return nil // want "error is not nil \\(line 7\\) but it returns nil"
+	}
+
+	defer dont()
+
+	if err := do(); err != nil {
+		return nil // want "error is not nil \\(line 13\\) but it returns nil"
+	}
+	if err := do(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func simpleFuncWith2ndErr() ([]byte, error) {
+	if err := do(); err != nil {
+		return nil, err
+	}
+	if err := do(); err != nil {
+		return nil, nil // want "error is not nil \\(line 27\\) but it returns nil"
+	}
+
+	defer dont()
+
+	if err := do(); err != nil {
+		return nil, nil // want "error is not nil \\(line 33\\) but it returns nil"
+	}
+	if err := do(); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func simpleFuncWithoutErr() []byte {
+	if err := do(); err != nil {
+		return nil
+	}
+	if err := do(); err != nil {
+		return nil
+	}
+
+	defer dont()
+
+	if err := do(); err != nil {
+		return nil
+	}
+	if err := do(); err != nil {
+		return nil
+	}
+
+	return nil
+}
+
+func simpleFuncWithoutRet() {
+	if err := do(); err != nil {
+		return
+	}
+	if err := do(); err != nil {
+		return
+	}
+
+	defer dont()
+
+	if err := do(); err != nil {
+		return
+	}
+	if err := do(); err != nil {
+		return
+	}
+
+	return
+}
+
+// -----
+
+func do() error {
+	return nil
+}
+
+func dont() {}


### PR DESCRIPTION
this is likely a regression, because this was working fine within [golangci-lint  v1.58.2](https://github.com/golangci/golangci-lint/tree/v1.58.2) ([nilerr v0.1.1](https://github.com/gostaticanalysis/nilerr/tree/v0.1.1))

the minimal example would be
```go
package defers

func simpleFuncWithOneErr() error {
	if err := do(); err != nil {
		return nil // want "error is not nil \\(line 4\\) but it returns nil"
	}

	defer dont()

	return nil
}

func do() error {
	return nil
}

func dont() {}
```